### PR TITLE
- Handled error output string when there is no error.

### DIFF
--- a/services/commandExe.go
+++ b/services/commandExe.go
@@ -23,10 +23,8 @@ func Execute(outputBuffer *bytes.Buffer, stack []*exec.Cmd) (errorOutput string)
 	var errStr string
 	if err := call(stack, pipeStack); err != nil {
 		fmt.Println ("Encountered Error", string(errorBuffer.Bytes()), err)
+		errStr = err.Error()
 	}
-	errorOutput= string(errorBuffer.Bytes())
-	return
-
 
 	if errStr != "" && errorBuffer.Bytes() != nil {
 		return fmt.Sprintf("%v\n%v", errStr, string(errorBuffer.Bytes()))


### PR DESCRIPTION
- Combined command (toJson/run) into running variable mode option.
- Used method returned variables instead of file global variables.

## Additions

- Method variables
- Added toJson to mode option

## Removals

- File variables
- Variable command

## CLI

```./ec_agent -i test_data/input/SAE-SHB-APP-Docker_1.17.x-20171028-V1.02R2.xlsx -o test_data/output/irina.json -m toJson```
```./ec_agent -i control_2.json -o test_data/output/irina.txt -m local```

## Review

- @imuchnik 

[Preview this PR without the whitespace changes](?w=0)





